### PR TITLE
Add package_from_path method to ParsePackwerk

### DIFF
--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -46,10 +46,10 @@ module ParsePackwerk
     path_string = file_path.to_s
     @package_from_path = T.let(@package_from_path, T.nilable(T::Hash[String, Package]))
     @package_from_path ||= {}
-    @package_from_path[path_string] ||= begin
+    @package_from_path[path_string] ||= T.must(begin
       matching_package = all.find { |package| path_string.start_with?("#{package.name}/") || path_string == package.name }
       matching_package || find(ROOT_PACKAGE_NAME)
-    end
+    end)
   end
 
   sig { params(package: ParsePackwerk::Package).void }

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -20,6 +20,8 @@ module ParsePackwerk
     end
   end
 
+  ROOT_PACKAGE_NAME = "."
+
   extend T::Sig
 
   sig do
@@ -44,7 +46,10 @@ module ParsePackwerk
     path_string = file_path.to_s
     @package_from_path = T.let(@package_from_path, T.nilable(T::Hash[String, Package]))
     @package_from_path ||= {}
-    @package_from_path[path_string] ||= all.find { |package| path_string.start_with? package.name }
+    @package_from_path[path_string] ||= begin
+      matching_package = all.find { |package| path_string.start_with?("#{package.name}/") || path_string == package.name }
+      matching_package || find(ROOT_PACKAGE_NAME)
+    end
   end
 
   sig { params(package: ParsePackwerk::Package).void }

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -20,8 +20,6 @@ module ParsePackwerk
     end
   end
 
-  ROOT_PACKAGE_NAME = "."
-
   extend T::Sig
 
   sig do

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -39,6 +39,14 @@ module ParsePackwerk
     Configuration.fetch
   end
 
+  sig { params(file_path: T.any(Pathname, String)).returns(T.nilable(Package)) }
+  def self.package_from_path(file_path)
+    path_string = file_path.to_s
+    @package_from_path = T.let(@package_from_path, T.nilable(T::Hash[String, Package]))
+    @package_from_path ||= {}
+    @package_from_path[path_string] ||= all.find { |package| path_string.start_with? package.name }
+  end
+
   sig { params(package: ParsePackwerk::Package).void }
   def self.write_package_yml!(package)
     FileUtils.mkdir_p(package.directory)

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -593,6 +593,49 @@ RSpec.describe ParsePackwerk do
     end
   end
 
+  describe 'ParsePackwerk.package_from_path' do
+    before do
+      write_file('packs/package_1/package.yml', <<~CONTENTS)
+          enforce_dependencies: true
+          enforce_privacy: true
+      CONTENTS
+    end
+
+    context 'given a filepath in the pack' do
+      let(:filepath) { 'packs/package_1/path/to/file.rb' }
+
+      let(:expected_package) do
+        ParsePackwerk::Package.new(
+          name: 'packs/package_1',
+          enforce_dependencies: true,
+          enforce_privacy: true,
+          dependencies: [],
+          metadata: {},
+        )
+      end
+
+      it 'returns the correct package' do
+        package = ParsePackwerk.package_from_path(filepath)
+
+        expect(package).to have_attributes({
+          name: expected_package.name,
+          enforce_dependencies: expected_package.enforce_dependencies,
+          enforce_privacy: expected_package.enforce_privacy,
+        })
+      end
+    end
+
+    context 'given an bad filepath' do
+      let(:filepath) { 'something/random' }
+
+      it 'returns nil' do
+        package = ParsePackwerk.package_from_path(filepath)
+
+        expect(package).to be_nil
+      end
+    end
+  end
+
   describe 'ParsePackwerk.write_package_yml' do
     let(:package_dir) { Pathname.new('packs/example_pack') }
     let(:package_yml) { package_dir.join('package.yml') }

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -596,42 +596,104 @@ RSpec.describe ParsePackwerk do
   describe 'ParsePackwerk.package_from_path' do
     before do
       write_file('packs/package_1/package.yml', <<~CONTENTS)
-          enforce_dependencies: true
-          enforce_privacy: true
+        enforce_dependencies: true
+        enforce_privacy: true
+      CONTENTS
+
+      write_file('packs/package_1_new/package.yml', <<~CONTENTS)
+        enforce_dependencies: true
+        enforce_privacy: false
+      CONTENTS
+
+      write_file('package.yml', <<~CONTENTS)
+        enforce_dependencies: false
+        enforce_privacy: false
       CONTENTS
     end
 
-    context 'given a filepath in the pack' do
-      let(:filepath) { 'packs/package_1/path/to/file.rb' }
-
-      let(:expected_package) do
-        ParsePackwerk::Package.new(
-          name: 'packs/package_1',
-          enforce_dependencies: true,
-          enforce_privacy: true,
-          dependencies: [],
-          metadata: {},
+    let(:expected_package_1) do
+      ParsePackwerk::Package.new(
+        name: 'packs/package_1',
+        enforce_dependencies: true,
+        enforce_privacy: true,
+        dependencies: [],
+        metadata: {},
         )
-      end
+    end
+
+    let(:expected_package_1_new) do
+      ParsePackwerk::Package.new(
+        name: 'packs/package_1_new',
+        enforce_dependencies: true,
+        enforce_privacy: false,
+        dependencies: [],
+        metadata: {},
+        )
+    end
+
+    context 'given a filepath in pack_1' do
+      let(:filepath) { 'packs/package_1/path/to/file.rb' }
 
       it 'returns the correct package' do
         package = ParsePackwerk.package_from_path(filepath)
 
         expect(package).to have_attributes({
-          name: expected_package.name,
-          enforce_dependencies: expected_package.enforce_dependencies,
-          enforce_privacy: expected_package.enforce_privacy,
+          name: expected_package_1.name,
+          enforce_dependencies: expected_package_1.enforce_dependencies,
+          enforce_privacy: expected_package_1.enforce_privacy,
         })
       end
     end
 
-    context 'given an bad filepath' do
-      let(:filepath) { 'something/random' }
+    context 'given a file path in pack_1_new' do
+      let(:filepath) { 'packs/package_1_new/path/to/file.rb' }
 
-      it 'returns nil' do
+      it 'returns the correct package' do
         package = ParsePackwerk.package_from_path(filepath)
 
-        expect(package).to be_nil
+        expect(package).to have_attributes({
+          name: expected_package_1_new.name,
+          enforce_dependencies: expected_package_1_new.enforce_dependencies,
+          enforce_privacy: expected_package_1_new.enforce_privacy,
+        })
+      end
+    end
+
+    context 'given a file path that is exactly the root of a pack' do
+      let(:filepath) { 'packs/package_1' }
+
+      it 'returns the correct pack' do
+        package = ParsePackwerk.package_from_path(filepath)
+
+        expect(package).to have_attributes({
+          name: expected_package_1.name,
+          enforce_dependencies: expected_package_1.enforce_dependencies,
+          enforce_privacy: expected_package_1.enforce_privacy,
+        })
+      end
+    end
+
+    context 'given a file path not in a pack' do
+      let(:filepath) { 'path/to/file.rb' }
+
+      let(:expected_root_package) do
+        ParsePackwerk::Package.new(
+          name: '.',
+          enforce_dependencies: false,
+          enforce_privacy: false,
+          dependencies: [],
+          metadata: {},
+          )
+      end
+
+      it 'returns the root pack' do
+        package = ParsePackwerk.package_from_path(filepath)
+
+        expect(package).to have_attributes({
+          name: expected_root_package.name,
+          enforce_dependencies: expected_root_package.enforce_dependencies,
+          enforce_privacy: expected_root_package.enforce_privacy,
+        })
       end
     end
   end


### PR DESCRIPTION
Allows a user to get a `Package` object from a filepath. The results are
memoized to provide fast subsequent lookups on the same filepath.
