### PR TITLE
Adds serialization and direct violation access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 This gem is meant to give a way to parse the various YML files that come with [`packwerk`](https://github.com/Shopify/packwerk).
 
 # Usage
+
 ```ruby
 # Get all packages
 # Note that currently, this does not respect configuration in `packwerk.yml`
 packages = ParsePackwerk.all
 
-# Get a single package with a given ame
+# Get a single package with a given name
 package = ParsePackwerk.find('packs/my_pack')
+
+# Get the violations from a package
+package.violations
 
 # Get a structured `deprecated_references.yml` object a single package
 deprecated_references = ParsePackwerk::DeprecatedReferences.for(package)

--- a/lib/parse_packwerk/deprecated_references.rb
+++ b/lib/parse_packwerk/deprecated_references.rb
@@ -46,5 +46,13 @@ module ParsePackwerk
         )
       end
     end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    def to_h
+      {
+        pathname: pathname,
+        violations: violations.map(&:to_h)
+      }
+    end
   end
 end

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -43,5 +43,22 @@ module ParsePackwerk
     def enforces_privacy?
       enforce_privacy
     end
+
+    sig { returns(T::Array[Violation]) }
+    def violations
+      DeprecatedReferences.for(self).violations
+    end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    def to_h
+      {
+        name: name,
+        enforce_dependencies: enforce_dependencies,
+        enforce_privacy: enforce_privacy,
+        metadata: metadata,
+        dependencies: dependencies,
+        violations: violations
+      }
+    end
   end
 end

--- a/lib/parse_packwerk/violation.rb
+++ b/lib/parse_packwerk/violation.rb
@@ -18,5 +18,15 @@ module ParsePackwerk
     def privacy?
       type == 'privacy'
     end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    def to_h
+      {
+        type: type,
+        package_name: to_package_name,
+        class_name: class_name,
+        files: files
+      }
+    end
   end
 end


### PR DESCRIPTION
This change adds serialization options for converting violations,
packages, and deprecated references into hashes for portability. It also
introduces direct access to `violations` via packs.