### PR TITLE
Add tests to ensure ParsePackwerk can handle nested packs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.11.0)
+    parse_packwerk (0.12.0)
       sorbet-runtime
 
 GEM

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.11.0'
+  spec.version       = '0.12.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe ParsePackwerk do
+  before do
+    ParsePackwerk.bust_cache!
+  end
+
   def hashify_violations(violations)
     violations.map { |v| hashify_violation(v) }
   end

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -511,6 +511,32 @@ RSpec.describe ParsePackwerk do
         expect(all_packages.find{|p| p.name == 'packs/my_pack'}).to_not be_nil
       end
     end
+
+    context 'in an app with nested packs' do
+      before do
+        write_file('package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+
+        write_file('packs/my_pack/package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+
+        write_file('packs/my_pack/subpack/package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+      end
+
+      it 'includes the correct set of packages' do
+        expect(all_packages.count).to eq 3
+        expect(all_packages.find{|p| p.name == '.'}).to_not be_nil
+        expect(all_packages.find{|p| p.name == 'packs/my_pack'}).to_not be_nil
+        expect(all_packages.find{|p| p.name == 'packs/my_pack/subpack'}).to_not be_nil
+      end
+    end
   end
 
   describe '.yml' do
@@ -694,6 +720,34 @@ RSpec.describe ParsePackwerk do
           enforce_dependencies: expected_root_package.enforce_dependencies,
           enforce_privacy: expected_root_package.enforce_privacy,
         })
+      end
+    end
+
+    context 'in an app with nested packs' do
+      before do
+        write_file('package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+
+        write_file('packs/my_pack/package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+
+        write_file('packs/my_pack/file.rb')
+
+        write_file('packs/my_pack/subpack/package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+          enforce_privacy: false
+        CONTENTS
+
+        write_file('packs/my_pack/subpack/file.rb')
+      end
+
+      it 'distinguishes between files in nested packs and parent packs' do
+        expect(ParsePackwerk.package_from_path('packs/my_pack/subpack/file.rb').name).to eq 'packs/my_pack/subpack'
+        expect(ParsePackwerk.package_from_path('packs/my_pack/file.rb').name).to eq 'packs/my_pack'
       end
     end
   end


### PR DESCRIPTION
I added tests to confirm nested packs will work (and continue to work) as expected.

This worked fine until I realized our implementation of `package_from_path` wouldn't always work as expected (tests passed locally but thankfully failed in CI due to a different file system load order). I corrected this by sorting the packages before storing them.

I added a `bust_cache!` method because I made `ParsePackwerk.all` use the cache, which will require that some other tools in the ecosystem call `ParsePackwerk.bust_cache!` in a `before` block in their tests.
