### PR TITLE
Update sig for ParsePackwerk.package_from_path so it always returns a Package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.12.0)
+    parse_packwerk (0.12.1)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -39,7 +39,7 @@ module ParsePackwerk
     Configuration.fetch
   end
 
-  sig { params(file_path: T.any(Pathname, String)).returns(T.nilable(Package)) }
+  sig { params(file_path: T.any(Pathname, String)).returns(Package) }
   def self.package_from_path(file_path)
     path_string = file_path.to_s
     @package_from_path = T.let(@package_from_path, T.nilable(T::Hash[String, Package]))

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.12.0'
+  spec.version       = '0.12.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'


### PR DESCRIPTION
Small change but makes client calls better type checked.