### PR TITLE
Add Package.public_path

### DIFF
--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -61,6 +61,13 @@ module ParsePackwerk
         enforce_privacy: #{package.enforces_privacy?}
       PACKAGEYML
 
+      unless package.public_path == DEFAULT_PUBLIC_PATH
+        public_path = <<~PUBLICPATH
+          public_path: #{package.public_path}
+        PUBLICPATH
+        package_yml += public_path
+      end
+
       if package.dependencies.any?
         dependencies = <<~STATEDDEPS
           dependencies:

--- a/lib/parse_packwerk/constants.rb
+++ b/lib/parse_packwerk/constants.rb
@@ -7,6 +7,7 @@ module ParsePackwerk
   DEPRECATED_REFERENCES_YML_NAME = T.let('deprecated_references.yml'.freeze, String)
   ENFORCE_DEPENDENCIES = T.let('enforce_dependencies'.freeze, String)
   ENFORCE_PRIVACY = T.let('enforce_privacy'.freeze, String)
+  PUBLIC_PATH = T.let('public_path'.freeze, String)
   METADATA = T.let('metadata'.freeze, String)
   DEPENDENCIES = T.let('dependencies'.freeze, String)
 
@@ -18,4 +19,5 @@ module ParsePackwerk
 
   DEFAULT_EXCLUDE_GLOBS = T.let(["{bin,node_modules,script,tmp,vendor}/**/*"], T::Array[String])
   DEFAULT_PACKAGE_PATHS = T.let(['**/'], T::Array[String])
+  DEFAULT_PUBLIC_PATH = T.let('app/public', String)
 end

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -7,6 +7,7 @@ module ParsePackwerk
     const :name, String
     const :enforce_dependencies, T::Boolean
     const :enforce_privacy, T::Boolean
+    const :public_path, String, default: DEFAULT_PUBLIC_PATH
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
 
@@ -19,6 +20,7 @@ module ParsePackwerk
         name: package_name,
         enforce_dependencies: package_loaded_yml[ENFORCE_DEPENDENCIES] ? true : false,
         enforce_privacy: package_loaded_yml[ENFORCE_PRIVACY] ? true : false,
+        public_path: package_loaded_yml[PUBLIC_PATH] || DEFAULT_PUBLIC_PATH,
         metadata: package_loaded_yml[METADATA] || {},
         dependencies: package_loaded_yml[DEPENDENCIES] || []
       )
@@ -32,6 +34,11 @@ module ParsePackwerk
     sig { returns(Pathname) }
     def directory
       Pathname.new(name).cleanpath
+    end
+
+    sig { returns(Pathname) }
+    def public_directory
+      directory.join(public_path).cleanpath
     end
 
     sig { returns(T::Boolean) }

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -150,6 +150,73 @@ RSpec.describe ParsePackwerk do
       it { is_expected.to have_matching_package expected_domain_package, expected_domain_package_deprecated_references }
     end
 
+    context 'in app that has public_path' do
+      before do
+        write_file('packs/package_1/package.yml', <<~CONTENTS)
+          enforce_dependencies: true
+          enforce_privacy: true
+          public_path: other/path
+        CONTENTS
+
+        write_file('package.yml', <<~CONTENTS)
+          # This file represents the root package of the application
+          # Please validate the configuration using `bin/packwerk validate` (for Rails applications) or running the auto generated
+          # test case (for non-Rails projects). You can then use `packwerk check` to check your code.
+          
+          # Turn on dependency checks for this package
+          enforce_dependencies: false
+          
+          # Turn on privacy checks for this package
+          # enforcing privacy is often not useful for the root package, because it would require defining a public interface
+          # for something that should only be a thin wrapper in the first place.
+          # We recommend enabling this for any new packages you create to aid with encapsulation.
+          enforce_privacy: false
+          
+          # By default the public path will be app/public/, however this may not suit all applications' architecture so
+          # this allows you to modify what your package's public path is.
+          # public_path: app/public/
+          
+          # A list of this package's dependencies
+          # Note that packages in this list require their own `package.yml` file
+          dependencies:
+        CONTENTS
+      end
+
+      let(:expected_root_package) do
+        ParsePackwerk::Package.new(
+          name: '.',
+          enforce_dependencies: false,
+          enforce_privacy: false,
+          public_path: 'app/public',
+          dependencies: [],
+          metadata: {},
+        )
+      end
+
+      let(:expected_root_deprecated_refereces) do
+        ParsePackwerk::DeprecatedReferences.from(Pathname.new('deprecated_references.yml'))
+      end
+
+      it { is_expected.to have_matching_package expected_root_package, expected_root_deprecated_refereces }
+
+      let(:expected_domain_package) do
+        ParsePackwerk::Package.new(
+          name: 'packs/package_1',
+          enforce_dependencies: true,
+          enforce_privacy: true,
+          public_path: 'other/path',
+          dependencies: [],
+          metadata: {},
+        )
+      end
+
+      let(:expected_deprecated_references) do
+        ParsePackwerk::DeprecatedReferences.from(Pathname.new('packs/package_1/deprecated_references.yml'))
+      end
+
+      it { is_expected.to have_matching_package expected_domain_package, expected_deprecated_references }
+    end
+
     context 'in app that has metadata' do
       before do
         write_file('packs/package_1/package.yml', <<~CONTENTS)
@@ -761,11 +828,12 @@ RSpec.describe ParsePackwerk do
     let(:package_yml) { package_dir.join('package.yml') }
     let(:deprecated_references_yml) { package_dir.join('deprecated_references.yml') }
 
-    def build_pack(dependencies: [], metadata: {})
+    def build_pack(public_path: 'app/public', dependencies: [], metadata: {})
       ParsePackwerk::Package.new(
         name: package_dir.to_s,
         enforce_dependencies: true,
         enforce_privacy: true,
+        public_path: public_path,
         dependencies: dependencies,
         metadata: metadata
       )
@@ -794,6 +862,25 @@ RSpec.describe ParsePackwerk do
         expect(all_packages.count).to eq 1
         expect(pack_as_hash(all_packages.first)).to eq pack_as_hash(package)
       end
+    end
+
+    context 'package with public_path' do
+      let(:package) do
+        build_pack(public_path: 'other/path')
+      end
+
+      it 'writes the right package' do
+        ParsePackwerk.write_package_yml!(package)
+        expect(package_yml.read).to eq <<~PACKAGEYML
+          enforce_dependencies: true
+          enforce_privacy: true
+          public_path: other/path
+        PACKAGEYML
+
+        expect(all_packages.count).to eq 1
+        expect(pack_as_hash(all_packages.first)).to eq pack_as_hash(package)
+      end
+
     end
 
     context 'package with dependencies' do


### PR DESCRIPTION
Packwerk supports defining a custom `public_path`, this adds support for parsing that https://github.com/Shopify/packwerk/blob/main/USAGE.md#defining-your-own-public-folder