### PR TITLE
Support removing the package dependency list from an existing package

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.18.1)
+    parse_packwerk (0.18.2)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -77,7 +77,9 @@ module ParsePackwerk
         merged_config.merge!('public_path' => package.public_path)
       end
 
-      if package.dependencies.any?
+      if package.dependencies.nil? || package.dependencies.none?
+        merged_config.delete('dependencies')
+      else
         merged_config.merge!('dependencies' => package.dependencies)
       end
 

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.18.1'
+  spec.version       = '0.18.2'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -1012,6 +1012,34 @@ RSpec.describe ParsePackwerk do
         expect(all_packages.count).to eq 1
         expect(pack_as_hash(all_packages.first)).to eq pack_as_hash(package)
       end
+
+      context 'overwriting an existing package file' do
+        before do
+          write_file(package_yml, <<~CONTENTS)
+            enforce_dependencies: true
+            enforce_privacy: true
+            public_path: other/path
+            dependencies:
+            - packs/package_2
+          CONTENTS
+        end
+
+        let(:existing_package) do
+          ParsePackwerk.find('packs/example_pack')
+        end
+
+        it 'allows you to remove the dependencies list' do
+          new_package = existing_package.with(dependencies: [])
+
+          ParsePackwerk.write_package_yml!(new_package)
+
+          expect(package_yml.read).to eq <<~PACKAGEYML
+            enforce_dependencies: true
+            enforce_privacy: true
+            public_path: other/path
+          PACKAGEYML
+        end
+      end
     end
 
     context 'package with other top-level config' do


### PR DESCRIPTION
This change allows callers to change the dependencies of a package to a blank list. On doing so, any pre-existing dependencies list in the yml file will be deleted - rather than preserved.

Detail:

When writing a new yml file, the #write_package_yml! method tries to keep the existing yml config intact so far as possible, so as to preserve custom fields/data in the yml file.

The `data` attribute on ParsePackwerk::Package contains the original config, and the attributes supplied as parameters to ParsePackwerk::Package.new contain the new values that the config _should_ be.

The existing implementation worked fine for other attributes, but the `dependencies` check used `package.dependencies.any?`

Since the `any?` method returns false if the array is blank, this meant that any attempt to overwrite the existing package list with a blank list kept the original items intact... rather than deleting the clause from the yml file

This change allows the caller to supply either `dependencies: nil` OR `dependencies: []` and the output file that `ParsePackwerk.write_package_yml!` creates will then no it's `dependencies` clause removed entirely.