### PR TITLE
Allow parse_packwerk to be aware of packwerk extension system

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.18.2)
+    parse_packwerk (0.19.0)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -9,6 +9,7 @@ require 'parse_packwerk/package_todo'
 require 'parse_packwerk/package'
 require 'parse_packwerk/configuration'
 require 'parse_packwerk/package_set'
+require 'parse_packwerk/extensions'
 
 module ParsePackwerk
   class MissingConfiguration < StandardError
@@ -57,10 +58,11 @@ module ParsePackwerk
     File.open(package.yml, 'w') do |file|
       merged_config = package.config
 
-      merged_config.merge!(
-        'enforce_dependencies' => package.enforce_dependencies,
-        'enforce_privacy' => package.enforce_privacy
-      )
+      merged_config.merge!('enforce_dependencies' => package.enforce_dependencies,)
+
+      if Extensions.privacy_extension_installed?
+        merged_config.merge!('enforce_privacy' => package.enforce_privacy)
+      end
 
       # We want checkers of the form `enforce_xyz` to be at the top
       merged_config_arr = merged_config.sort_by do |k, v|

--- a/lib/parse_packwerk/configuration.rb
+++ b/lib/parse_packwerk/configuration.rb
@@ -6,6 +6,7 @@ module ParsePackwerk
 
     const :exclude, T::Array[String]
     const :package_paths, T::Array[String]
+    const :requires, T::Array[String]
 
     sig { returns(Configuration) }
     def self.fetch
@@ -21,6 +22,7 @@ module ParsePackwerk
       Configuration.new(
         exclude: excludes(raw_packwerk_config),
         package_paths: package_paths(raw_packwerk_config),
+        requires: raw_packwerk_config['require'] || []
       )
     end
 

--- a/lib/parse_packwerk/extensions.rb
+++ b/lib/parse_packwerk/extensions.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module ParsePackwerk
+  module Extensions
+    extend T::Sig
+
+    sig { returns(T::Boolean) }
+    def self.all_extensions_installed?
+      ParsePackwerk.yml.requires.include?('packwerk-extensions')
+    end
+
+    sig { returns(T::Boolean) }
+    def self.privacy_extension_installed?
+      all_extensions_installed? || ParsePackwerk.yml.requires.include?('packwerk/privacy/checker')
+    end
+  end
+
+  private_constant :Extensions
+end

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -6,7 +6,7 @@ module ParsePackwerk
 
     const :name, String
     const :enforce_dependencies, T.any(T::Boolean, String)
-    const :enforce_privacy, T.any(T::Boolean, String)
+    const :enforce_privacy, T.any(T::Boolean, String), default: false
     const :public_path, String, default: DEFAULT_PUBLIC_PATH
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
@@ -20,7 +20,7 @@ module ParsePackwerk
       new(
         name: package_name,
         enforce_dependencies: package_loaded_yml[ENFORCE_DEPENDENCIES],
-        enforce_privacy: package_loaded_yml[ENFORCE_PRIVACY],
+        enforce_privacy: package_loaded_yml[ENFORCE_PRIVACY] || false,
         public_path: package_loaded_yml[PUBLIC_PATH] || DEFAULT_PUBLIC_PATH,
         metadata: package_loaded_yml[METADATA] || {},
         dependencies: package_loaded_yml[DEPENDENCIES] || [],

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.18.2'
+  spec.version       = '0.19.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -1113,7 +1113,7 @@ RSpec.describe ParsePackwerk do
         write_file('packwerk.yml', '{}')
       end
 
-      let(:package) { build_pack }
+      let(:package) { build_pack(enforce_privacy: false) }
 
       it 'writes the right package' do
         ParsePackwerk.write_package_yml!(package)

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -626,6 +626,40 @@ RSpec.describe ParsePackwerk do
         expect(all_packages.find{|p| p.name == 'packs/my_pack/subpack'}).to_not be_nil
       end
     end
+
+    context 'in an app that does not use privacy checker' do
+      before do
+        write_file('package.yml', <<~CONTENTS)
+          enforce_dependencies: false
+        CONTENTS
+      end
+
+      let(:expected_package) do
+        ParsePackwerk::Package.new(
+          name: '.',
+          enforce_dependencies: false,
+          enforce_privacy: false,
+          dependencies: [],
+          metadata: {},
+          config: {},
+        )
+      end
+
+      let(:expected_package_todo) do
+        ParsePackwerk::PackageTodo.from(Pathname.new('package_todo.yml'))
+      end
+
+      it 'correctly finds the package YML' do
+        expect(expected_package.yml).to eq Pathname.new('package.yml')
+      end
+
+      it 'correctly finds the package directory' do
+        expect(expected_package.directory).to eq Pathname.new('.')
+      end
+
+      it { is_expected.to have_matching_package expected_package, expected_package_todo }
+    end
+
   end
 
   describe 'ParsePackwerk::Package#violations' do

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -2,7 +2,15 @@
 
 RSpec.describe ParsePackwerk do
   before do
+    write_packwerk_yml
     ParsePackwerk.bust_cache!
+  end
+
+  let(:write_packwerk_yml) do
+    write_file('packwerk.yml', <<~YML)
+      require:
+        - packwerk-extensions
+      YML
   end
 
   def hashify_violations(violations)
@@ -1059,6 +1067,24 @@ RSpec.describe ParsePackwerk do
           my_special_key:
             blah: 1
           my_other_special_key: true
+        PACKAGEYML
+
+        expect(all_packages.count).to eq 1
+        expect(pack_as_hash(all_packages.first)).to eq pack_as_hash(package)
+      end
+    end
+
+    context 'app does not use privacy checker' do
+      let(:write_packwerk_yml) do
+        write_file('packwerk.yml', '{}')
+      end
+
+      let(:package) { build_pack }
+
+      it 'writes the right package' do
+        ParsePackwerk.write_package_yml!(package)
+        expect(package_yml.read).to eq <<~PACKAGEYML
+          enforce_dependencies: true
         PACKAGEYML
 
         expect(all_packages.count).to eq 1


### PR DESCRIPTION
We found that on a new app with `packwerk`, `use_packs` creates packages that fail `bin/packwerk validate`, since by default, a package cannot have `enforce_privacy` set unless `packwerk-extensions` is installed.

`parse_packwerk` should be aware of `packwerk-extensions` and only add `enforce_privacy` if the privacy checker is added.

I added some more context on specific design choices as PR comments.

Fixes https://github.com/rubyatscale/parse_packwerk/issues/23