### PR TITLE
Improve output when there is an empty package.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.19.0)
+    parse_packwerk (0.19.1)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -12,6 +12,9 @@ require 'parse_packwerk/package_set'
 require 'parse_packwerk/extensions'
 
 module ParsePackwerk
+  class PackageParseError < StandardError
+  end
+
   class MissingConfiguration < StandardError
     extend T::Sig
 

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -15,6 +15,10 @@ module ParsePackwerk
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)
       package_loaded_yml = YAML.load_file(pathname)
+      if package_loaded_yml == false
+        message = "Failed to parse `#{pathname}`. Please fix any issues with this package.yml OR add its containing folder to packwerk.yml `exclude`"
+        raise PackageParseError.new(message)
+      end
       package_name = pathname.dirname.cleanpath.to_s
 
       new(

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -15,7 +15,7 @@ module ParsePackwerk
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)
       package_loaded_yml = YAML.load_file(pathname)
-      if package_loaded_yml == false
+      if package_loaded_yml.nil? || package_loaded_yml == false
         message = "Failed to parse `#{pathname}`. Please fix any issues with this package.yml OR add its containing folder to packwerk.yml `exclude`"
         raise PackageParseError.new(message)
       end

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.19.0'
+  spec.version       = '0.19.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -660,6 +660,16 @@ RSpec.describe ParsePackwerk do
       it { is_expected.to have_matching_package expected_package, expected_package_todo }
     end
 
+    context 'in app with an invalid package.yml' do
+      before do
+        write_file('packs/my_pack/package.yml', <<~CONTENTS)
+        CONTENTS
+      end
+
+      it 'outputs an error message with the pathname' do
+        expect{subject}.to raise_error(NoMethodError, /undefined method `\[\]' for false:FalseClass/)
+      end
+    end
   end
 
   describe 'ParsePackwerk::Package#violations' do

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -667,7 +667,7 @@ RSpec.describe ParsePackwerk do
       end
 
       it 'outputs an error message with the pathname' do
-        expect{subject}.to raise_error(NoMethodError, /undefined method `\[\]' for false:FalseClass/)
+        expect{subject}.to raise_error(ParsePackwerk::PackageParseError, /Failed to parse `packs\/my_pack\/package.yml`. Please fix any issues with this package.yml OR add its containing folder to packwerk.yml `exclude`/)
       end
     end
   end


### PR DESCRIPTION
This came up during the RailsConf workshop. A user was seeing the behavior demonstrated in the test written in the first commit.

In this case, the user vendored in their gems in `vendor/bundle`, which had this file: https://github.com/Shopify/packwerk/blob/main/test/fixtures/blank/package.yml

This test fixture from packwerk caused `ParsePackwerk` to break when scanning for packages.

Before, there would be no helpful output to indicate what file it was failing on, making it harder to adopt.