### PR TITLE
Require fileutils explicitly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.19.1)
+    parse_packwerk (0.19.2)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -3,6 +3,11 @@
 require 'sorbet-runtime'
 require 'yaml'
 require 'pathname'
+
+# fileutils is loaded by a development gem dependency, but requiring here so clients
+# do not get `uninitialized constant ParsePackwerk::FileUtils`
+require 'fileutils'
+
 require 'parse_packwerk/constants'
 require 'parse_packwerk/violation'
 require 'parse_packwerk/package_todo'

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.19.1'
+  spec.version       = '0.19.2'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'


### PR DESCRIPTION
When using `parse_packwerk` in an `irb` console, I'd get this error:

```
/Users/alex.evanczuk/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/parse_packwerk-0.19.1/lib/parse_packwerk.rb:59:in `write_package_yml!': uninitialized constant ParsePackwerk::FileUtils (NameError)

    FileUtils.mkdir_p(package.directory)
    ^^^^^^^^^
Did you mean?  FileTest
        from /Users/alex.evanczuk/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10821/lib/types/private/methods/call_validation.rb:256:in `bind_call'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10821/lib/types/private/methods/call_validation.rb:256:in `validate_call'
        from /Users/alex.evanczuk/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/sorbet-runtime-0.5.10821/lib/types/private/methods/_methods.rb:275:in `block in _on_method_added'
        from script.rb:22:in `block in <main>'
        from script.rb:9:in `each'
        from script.rb:9:in `<main>'
```

We should explicitly require `fileutils` to fix this.