### PR TITLE
Sort package.yml keys when writing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.19.2)
+    parse_packwerk (0.19.3)
       sorbet-runtime
 
 GEM

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "parse_packwerk"
-  spec.version       = '0.19.2'
+  spec.version       = '0.19.3'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'


### PR DESCRIPTION
As I'm improving `use_packs`, I'm realizing that `use_packs` needs to rely on a canonical sort order of keys that's the same that `parse_packwerk` uses when writing `package.yml` files initially.

Right now, this list refers to keys that are not in vanilla packwerk, but rather added by extensions, like `enforce_privacy` and `owner`. In theory, that's information this package should not know about, but since it is only knowing about the strings of these keys and how to sort them, I think it's okay for now, as it makes it much simpler to share the sort order.

A way to do this that better respects the extensible portions of the ecosystem is allowing the sort order to be dependency injected, perhaps by a gem like `use_packs` which knows about more systems, or by the user themselves (in case they have their own custom systems). That can be a change that is made when this approach becomes a problem.

Another idea is to have `write_package_yml` simply be an API somewhere else, e.g. `UsePacks`. This would make more sense when `UsePacks` is called `Packs` and `Packs` is called `Packs::Specification`