### PR TITLE
Allow violations to be set on a package

### DIFF
--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -11,6 +11,7 @@ module ParsePackwerk
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
     const :config, T::Hash[T.untyped, T.untyped]
+    const :stored_violations, T.nilable(T::Array[Violation])
 
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)
@@ -29,6 +30,7 @@ module ParsePackwerk
         metadata: package_loaded_yml[METADATA] || {},
         dependencies: package_loaded_yml[DEPENDENCIES] || [],
         config: package_loaded_yml,
+        stored_violations: nil
       )
     end
 
@@ -59,7 +61,7 @@ module ParsePackwerk
 
     sig { returns(T::Array[Violation]) }
     def violations
-      PackageTodo.for(self).violations
+      stored_violations || PackageTodo.for(self).violations
     end
   end
 end

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -11,7 +11,7 @@ module ParsePackwerk
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
     const :config, T::Hash[T.untyped, T.untyped]
-    const :stored_violations, T.nilable(T::Array[Violation])
+    const :violations, T.nilable(T::Array[Violation])
 
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)
@@ -30,8 +30,13 @@ module ParsePackwerk
         metadata: package_loaded_yml[METADATA] || {},
         dependencies: package_loaded_yml[DEPENDENCIES] || [],
         config: package_loaded_yml,
-        stored_violations: nil
+        violations: PackageTodo.from(PackageTodo.yml(directory(package_name))).violations
       )
+    end
+
+    sig { params(package_name: String).returns(::Pathname) }
+    def self.directory(package_name)
+      Pathname.new(package_name).cleanpath
     end
 
     sig { returns(Pathname) }
@@ -41,7 +46,7 @@ module ParsePackwerk
 
     sig { returns(Pathname) }
     def directory
-      Pathname.new(name).cleanpath
+      self.class.directory(self.name)
     end
 
     sig { returns(Pathname) }
@@ -57,11 +62,6 @@ module ParsePackwerk
     sig { returns(T.any(T::Boolean, String)) }
     def enforces_privacy?
       enforce_privacy
-    end
-
-    sig { returns(T::Array[Violation]) }
-    def violations
-      stored_violations || PackageTodo.for(self).violations
     end
   end
 end

--- a/lib/parse_packwerk/package_todo.rb
+++ b/lib/parse_packwerk/package_todo.rb
@@ -9,8 +9,7 @@ module ParsePackwerk
 
     sig { params(package: Package).returns(PackageTodo) }
     def self.for(package)
-      package_todo_yml_pathname = package.directory.join(PACKAGE_TODO_YML_NAME)
-      PackageTodo.from(package_todo_yml_pathname)
+      PackageTodo.from(self.yml(package.directory))
     end
 
     sig { params(pathname: Pathname).returns(PackageTodo) }
@@ -41,6 +40,11 @@ module ParsePackwerk
           violations: all_violations
         )
       end
+    end
+    
+    sig { params(dirname: Pathname).returns(Pathname) }
+    def self.yml(dirname)
+      dirname.join(PACKAGE_TODO_YML_NAME).cleanpath
     end
   end
 end


### PR DESCRIPTION
There are a situations where it is desirable to explicitly set the list package violations rather than have it be generated from the todo files stored on disk. This PR adds an optional parameter to do just this.

Today, specifically, https://github.com/shageman/visualize_packs uses this to give users the option of hiding nested packages. In this case it adds all nested violations to the parent-level pack. I believe there are more use-cases in the realm of analyzing the potential impact of violation changes to the overall graph structure.