### PR TITLE
Violations array is never nilable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,4 +87,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.4.10
+   2.4.21

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -11,7 +11,7 @@ module ParsePackwerk
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
     const :config, T::Hash[T.untyped, T.untyped]
-    const :violations, T.nilable(T::Array[Violation])
+    const :violations, T::Array[Violation]
 
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -13,19 +13,6 @@ RSpec.describe ParsePackwerk do
       YML
   end
 
-  def hashify_violations(violations)
-    violations.map { |v| hashify_violation(v) }
-  end
-
-  def hashify_violation(v)
-    {
-      type: v.type,
-      to_package_name: v.to_package_name,
-      class_name: v.to_package_name,
-      files: v.files
-    }
-  end
-
   subject(:all_packages) do
     ParsePackwerk.all
   end

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -126,6 +127,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -143,6 +145,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -202,6 +205,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -220,6 +224,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -274,6 +279,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -296,6 +302,7 @@ RSpec.describe ParsePackwerk do
             'numeric_key' => 123,
           },
           config: {},
+          violations: [],
         )
       end
 
@@ -420,6 +427,7 @@ RSpec.describe ParsePackwerk do
           dependencies: ['packs/package_2'],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -453,6 +461,7 @@ RSpec.describe ParsePackwerk do
           dependencies: ['packs/package_2'],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -480,6 +489,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -642,6 +652,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -833,6 +844,7 @@ RSpec.describe ParsePackwerk do
         dependencies: [],
         metadata: {},
         config: {},
+        violations: [],
       )
     end
 
@@ -844,6 +856,7 @@ RSpec.describe ParsePackwerk do
         dependencies: [],
         metadata: {},
         config: {},
+        violations: [],
       )
     end
 
@@ -900,6 +913,7 @@ RSpec.describe ParsePackwerk do
           dependencies: [],
           metadata: {},
           config: {},
+          violations: [],
         )
       end
 
@@ -957,6 +971,7 @@ RSpec.describe ParsePackwerk do
         dependencies: dependencies,
         metadata: metadata,
         config: config,
+        violations: [],
       )
     end
 

--- a/spec/support/have_matching_package.rb
+++ b/spec/support/have_matching_package.rb
@@ -13,6 +13,19 @@ RSpec::Matchers.define(:have_matching_package) do |expected_package, expected_pa
     "to have a package named #{expected_package.package_name.inspect} with identical attributes"
   end
 
+  def hashify_violations(violations)
+    violations.map { |v| hashify_violation(v) }
+  end
+
+  def hashify_violation(v)
+    {
+      type: v.type,
+      to_package_name: v.to_package_name,
+      class_name: v.to_package_name,
+      files: v.files
+    }
+  end
+
   def deep_hashify_package(package, package_todo)
     {
       name: package.name,


### PR DESCRIPTION
In #33, @technicalpickles noticed the violations array is nilable. In looking at the code and tests, I was not able to reproduce a case where the violations array is nil. 

The violations come from this struct which is always an array:
```
  class PackageTodo < T::Struct
    const :violations, T::Array[Violation]
```

My concern is that there could be another code path that would set this to nil, but I was not able to find it.

Fixes #33 