### PR TITLE
add enforce_architecture to pack configs if extension is enabled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.21.0)
+    parse_packwerk (0.22.0)
       sorbet-runtime
 
 GEM

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -72,6 +72,10 @@ module ParsePackwerk
         merged_config.merge!('enforce_privacy' => package.enforce_privacy)
       end
 
+      if Extensions.architecture_extension_installed?
+        merged_config.merge!('enforce_architecture' => package.enforce_architecture)
+      end
+
       unless package.public_path == DEFAULT_PUBLIC_PATH
         merged_config.merge!('public_path' => package.public_path)
       end

--- a/lib/parse_packwerk/constants.rb
+++ b/lib/parse_packwerk/constants.rb
@@ -7,6 +7,7 @@ module ParsePackwerk
   PACKAGE_TODO_YML_NAME = T.let('package_todo.yml'.freeze, String)
   ENFORCE_DEPENDENCIES = T.let('enforce_dependencies'.freeze, String)
   ENFORCE_PRIVACY = T.let('enforce_privacy'.freeze, String)
+  ENFORCE_ARCHITECTURE = T.let('enforce_architecture'.freeze, String)
   DEPENDENCY_VIOLATION_TYPE = T.let('dependency'.freeze, String)
   PRIVACY_VIOLATION_TYPE = T.let('privacy'.freeze, String)
   PUBLIC_PATH = T.let('public_path'.freeze, String)

--- a/lib/parse_packwerk/extensions.rb
+++ b/lib/parse_packwerk/extensions.rb
@@ -13,6 +13,11 @@ module ParsePackwerk
     def self.privacy_extension_installed?
       all_extensions_installed? || ParsePackwerk.yml.requires.include?('packwerk/privacy/checker')
     end
+
+    sig { returns(T::Boolean) }
+    def self.architecture_extension_installed?
+      all_extensions_installed? || ParsePackwerk.yml.requires.include?('packwerk/architecture/checker')
+    end
   end
 
   private_constant :Extensions

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -7,6 +7,7 @@ module ParsePackwerk
     const :name, String
     const :enforce_dependencies, T.nilable(T.any(T::Boolean, String))
     const :enforce_privacy, T.any(T::Boolean, String), default: false
+    const :enforce_architecture, T.any(T::Boolean, String), default: false
     const :public_path, String, default: DEFAULT_PUBLIC_PATH
     const :metadata, MetadataYmlType
     const :dependencies, T::Array[String]
@@ -26,6 +27,7 @@ module ParsePackwerk
         name: package_name,
         enforce_dependencies: package_loaded_yml[ENFORCE_DEPENDENCIES],
         enforce_privacy: package_loaded_yml[ENFORCE_PRIVACY] || false,
+        enforce_architecture: package_loaded_yml[ENFORCE_ARCHITECTURE] || false,
         public_path: package_loaded_yml[PUBLIC_PATH] || DEFAULT_PUBLIC_PATH,
         metadata: package_loaded_yml[METADATA] || {},
         dependencies: package_loaded_yml[DEPENDENCIES] || [],
@@ -62,6 +64,11 @@ module ParsePackwerk
     sig { returns(T.any(T::Boolean, String)) }
     def enforces_privacy?
       enforce_privacy
+    end
+
+    sig { returns(T.any(T::Boolean, String)) }
+    def enforces_architecture?
+      enforce_architecture
     end
   end
 end

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'parse_packwerk'
-  spec.version       = '0.21.0'
+  spec.version       = '0.22.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -967,11 +967,12 @@ RSpec.describe ParsePackwerk do
     let(:package_yml) { package_dir.join('package.yml') }
     let(:package_todo_yml) { package_dir.join('package_todo.yml') }
 
-    def build_pack(public_path: 'app/public', enforce_privacy: true, dependencies: [], metadata: {}, config: {})
+    def build_pack(public_path: 'app/public', enforce_privacy: true, enforce_architecture: true, dependencies: [], metadata: {}, config: {})
       ParsePackwerk::Package.new(
         name: package_dir.to_s,
         enforce_dependencies: true,
         enforce_privacy: enforce_privacy,
+        enforce_architecture: enforce_architecture,
         public_path: public_path,
         dependencies: dependencies,
         metadata: metadata,
@@ -985,6 +986,7 @@ RSpec.describe ParsePackwerk do
         name: package.name,
         enforce_dependencies: package.enforce_dependencies,
         enforce_privacy: package.enforce_privacy,
+        enforce_architecture: package.enforce_architecture,
         dependencies: package.dependencies,
         metadata: package.metadata
       }
@@ -998,6 +1000,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: true
+          enforce_architecture: true
         PACKAGEYML
 
         expect(all_packages.count).to eq 1
@@ -1015,6 +1018,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: true
+          enforce_architecture: true
           public_path: other/path
         PACKAGEYML
 
@@ -1033,6 +1037,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: strict
+          enforce_architecture: true
         PACKAGEYML
 
         expect(all_packages.count).to eq 1
@@ -1050,6 +1055,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: true
+          enforce_architecture: true
           dependencies:
             - my_other_pack1
             - my_other_pack2
@@ -1074,6 +1080,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: true
+          enforce_architecture: true
           metadata:
             owner: Mission > Team
             protections:
@@ -1090,6 +1097,7 @@ RSpec.describe ParsePackwerk do
           write_file(package_yml, <<~CONTENTS)
             enforce_dependencies: true
             enforce_privacy: true
+            enforce_architecture: true
             public_path: other/path
             dependencies:
             - packs/package2
@@ -1108,6 +1116,7 @@ RSpec.describe ParsePackwerk do
           expect(package_yml.read).to eq <<~PACKAGEYML
             enforce_dependencies: true
             enforce_privacy: true
+            enforce_architecture: true
             public_path: other/path
           PACKAGEYML
         end
@@ -1128,6 +1137,7 @@ RSpec.describe ParsePackwerk do
         expect(package_yml.read).to eq <<~PACKAGEYML
           enforce_dependencies: true
           enforce_privacy: true
+          enforce_architecture: true
           my_special_key:
             blah: 1
           my_other_special_key: true
@@ -1138,12 +1148,12 @@ RSpec.describe ParsePackwerk do
       end
     end
 
-    context 'app does not use privacy checker' do
+    context 'app does not use extensions' do
       let(:write_packwerk_yml) do
         write_file('packwerk.yml', '{}')
       end
 
-      let(:package) { build_pack(enforce_privacy: false) }
+      let(:package) { build_pack(enforce_privacy: false, enforce_architecture: false) }
 
       it 'writes the right package' do
         ParsePackwerk.write_package_yml!(package)


### PR DESCRIPTION
This adds `enforce_architecture` to the `ParsePackwerk::Package` typed struct, and other related functionality that mirrors the implementation for `enforce_privacy` (which is another [Packwerk extension](https://github.com/rubyatscale/packwerk-extensions/tree/main/lib/packwerk) and not a built-in feature).

This PR should be backwards-compatible with `packs` and other gems that rely on `parse_packwerk` (having a default value for the `T::Struct` attribute makes it optional). There is a [branch](https://github.com/rubyatscale/packs/compare/mod%2Fenforce-arch) in `packs` that I'll update and open a PR for once this is released. `packs` will have to require version `>= 0.22.0` of `parse_packwerk`.