### PR TITLE
allow empty package.yml files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.22.0)
+    parse_packwerk (0.23.0)
       bigdecimal
       sorbet-runtime
 

--- a/lib/parse_packwerk/package.rb
+++ b/lib/parse_packwerk/package.rb
@@ -16,11 +16,7 @@ module ParsePackwerk
 
     sig { params(pathname: Pathname).returns(Package) }
     def self.from(pathname)
-      package_loaded_yml = YAML.load_file(pathname)
-      if package_loaded_yml.nil? || package_loaded_yml == false
-        message = "Failed to parse `#{pathname}`. Please fix any issues with this package.yml OR add its containing folder to packwerk.yml `exclude`"
-        raise PackageParseError, message
-      end
+      package_loaded_yml = YAML.load_file(pathname) || {}
       package_name = pathname.dirname.cleanpath.to_s
 
       new(

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'parse_packwerk'
-  spec.version       = '0.22.0'
+  spec.version       = '0.23.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -677,13 +677,29 @@ RSpec.describe ParsePackwerk do
       it { is_expected.to have_matching_package expected_package, expected_package_todo }
     end
 
-    context 'in app with an invalid package.yml' do
+    context 'in app with an empty package.yml' do
+      let(:expected_package) do
+        ParsePackwerk::Package.new(
+          name: 'packs/my_pack',
+          enforce_dependencies: nil,
+          enforce_privacy: false,
+          dependencies: [],
+          metadata: {},
+          config: {},
+          violations: []
+        )
+      end
+
+      let(:expected_package_todo) do
+        ParsePackwerk::PackageTodo.for(expected_package)
+      end
+
       before do
         write_file('packs/my_pack/package.yml', '')
       end
 
-      it 'outputs an error message with the pathname' do
-        expect { subject }.to raise_error(ParsePackwerk::PackageParseError, %r{Failed to parse `packs/my_pack/package.yml`. Please fix any issues with this package.yml OR add its containing folder to packwerk.yml `exclude`})
+      it 'parses the file and returns a package with empty values' do
+        expect(subject).to have_matching_package(expected_package, expected_package_todo)
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rubyatscale/parse_packwerk/issues/41

If a package.yml file exists but is empty, we should interpret that as a valid package and initialize it with default values.