### PR TITLE
update ci; add shared stale and triage workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   call-workflow-from-shared-config:
     uses: rubyatscale/shared-config/.github/workflows/ci.yml@main
+    secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/stale.yml@main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,9 @@
+name: Label issues as "triage"
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/triage.yml@main


### PR DESCRIPTION
`secrets: inherit` is needed in CI for the Slack notification that triggers on failure.