### PR TITLE
don't manually indent yaml list items

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.25.0)
+    parse_packwerk (0.26.0)
       bigdecimal
       sorbet-runtime
 

--- a/lib/parse_packwerk.rb
+++ b/lib/parse_packwerk.rb
@@ -94,8 +94,6 @@ module ParsePackwerk
       merged_config = merged_config.to_a.sort_by { |key, _value| T.unsafe(sorted_keys).index(key) || 1000 }.to_h
 
       raw_yaml = YAML.dump(merged_config)
-      # Add indentation for dependencies
-      raw_yaml.gsub!(/^- /, '  - ')
       stylized_yaml = raw_yaml.gsub("---\n", '')
       file.write(stylized_yaml)
     end

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'parse_packwerk'
-  spec.version       = '0.25.0'
+  spec.version       = '0.26.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'

--- a/spec/parse_packwerk_spec.rb
+++ b/spec/parse_packwerk_spec.rb
@@ -1073,8 +1073,8 @@ RSpec.describe ParsePackwerk do
           enforce_privacy: true
           enforce_layers: true
           dependencies:
-            - my_other_pack1
-            - my_other_pack2
+          - my_other_pack1
+          - my_other_pack2
         PACKAGEYML
 
         expect(all_packages.count).to eq 1


### PR DESCRIPTION
Manually indenting these items was causing problems for configs that contain the new [enforcement_globs_ignore](https://github.com/alexevanczuk/packs/pull/189) key in pks.

```yaml
# this:
enforcement_globs_ignore:
- enforcements:
  - privacy
  ignores:
  - **/*
dependencies:
- other_pack

# was being reformatted to this:
enforcement_globs_ignore:
  - enforcements:
  - privacy
  ignores:
  - **/*
dependencies:
  - other_pack
```