### PR TITLE
Don't raise when we can't find a Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parse_packwerk (0.26.0)
+    parse_packwerk (0.26.1)
       bigdecimal
       sorbet-runtime
 

--- a/lib/parse_packwerk/configuration.rb
+++ b/lib/parse_packwerk/configuration.rb
@@ -40,7 +40,7 @@ module ParsePackwerk
       begin
         excludes.push Bundler.bundle_path.join('**').to_s
       rescue Bundler::GemfileNotFound
-        # Not using a Gemfile, so we can't add the bundle path.
+        # Optionally, add bundle to the path. Skip when there isn't a Gemfile.
       end
 
       excludes

--- a/lib/parse_packwerk/configuration.rb
+++ b/lib/parse_packwerk/configuration.rb
@@ -37,7 +37,13 @@ module ParsePackwerk
                    Array(specified_exclude)
                  end
 
-      excludes.push Bundler.bundle_path.join('**').to_s
+      begin
+        excludes.push Bundler.bundle_path.join('**').to_s
+      rescue Bundler::GemfileNotFound
+        # Not using a Gemfile, so we can't add the bundle path.
+      end
+
+      excludes
     end
 
     sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[String]) }

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'parse_packwerk'
-  spec.version       = '0.26.0'
+  spec.version       = '0.26.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for parsing and writing packwerk YML files'


### PR DESCRIPTION
Finding a Gemfile is not necessary for this to work, so be graceful when we aren't run in `bundle exec` environment.