### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`parse_packwerk` is a low-dependency Ruby gem for parsing and writing the YAML files that packwerk uses: `package.yml` (package config) and `package_todo.yml` (recorded violations).
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+
+# Lint
+bundle exec rubocop
+bundle exec rubocop -a  # auto-correct
+
+# Type checking (Sorbet)
+bundle exec srb tc
+```
+
+## Architecture
+
+- `lib/parse_packwerk.rb` — entry point; `ParsePackwerk.all` returns all packages
+- `lib/parse_packwerk/` — `Package` (parses `package.yml`), `PackageTodo` (parses `package_todo.yml`), and YAML write-back helpers that preserve comments and ordering
+- `spec/` — RSpec tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.