### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - vendor/bundle/**/**
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.3
 
 Metrics/ParameterLists:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,4 +114,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.4.21
+   4.0.15

--- a/parse_packwerk.gemspec
+++ b/parse_packwerk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'sorbet-runtime'


### PR DESCRIPTION
## Summary

Bumps the minimum supported Ruby version to 3.3 (Ruby 3.2 is now EOL; the supported set is 3.3 and 3.4).

### Changes

- **`parse_packwerk.gemspec`**: `spec.required_ruby_version` raised from `'>= 2.6'` to `'>= 3.3'`.
- **`.rubocop.yml`**: `AllCops.TargetRubyVersion` raised from `2.6` to `3.3`.

### Notes

- No `.ruby-version` / `.tool-versions` files exist in this repo, so none were changed.
- CI workflows (`.github/workflows/*.yml`) delegate to `rubyatscale/shared-config` reusable workflows and contain no inline Ruby version matrices, so no workflow edits were needed.
- The README has no explicit minimum-Ruby-version statement to update.
- Remaining `2.7`/`3.0`/`3.1` references are confined to generated Sorbet RBI files and version-specific comments, which were intentionally left untouched.

## Motivation

Resolves the Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.